### PR TITLE
Ignoring unknown field on (de)serialization.

### DIFF
--- a/marshmallow_autoschema/schema_factory.py
+++ b/marshmallow_autoschema/schema_factory.py
@@ -27,7 +27,7 @@ from functools import partial
 from inspect import Parameter, signature
 from typing import Callable, Generic, List, Optional, TypeVar, Union
 
-from marshmallow import fields, missing
+from marshmallow import fields, missing, EXCLUDE
 from marshmallow.fields import List as FieldList
 from marshmallow_enum import EnumField
 
@@ -309,6 +309,7 @@ class schema_metafactory:
             if SCHEMA_ATTRNAME in model_base.__dict__
         ) + (self.schema_base_class,)
 
+        schema_attrs['Meta'] = type('Meta', (object, ), {'unknown': EXCLUDE})
         schema_cls = type(
             get_schema_cls_name(model_cls), schema_bases, schema_attrs,
         )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -79,3 +79,14 @@ def test_load_validation():
     tampered_record = {'popularity': 1, 'links': ['1337']}
     with raises(ValidationError):
         MyPageRank.load(tampered_record)
+
+
+@autoschema
+class Foo:
+    def __init__(self, *, bar: str):
+        self._bar = bar
+
+
+def test_unknown_keys_are_silently_dropped():
+    data = {"bar": "value", "more": 1}
+    Foo.load(data)


### PR DESCRIPTION
marshmallow 3 is now strict by default so this change makes autoschema behave as it used to.
Could be configurable eventually if needed.